### PR TITLE
Fixing file handling error breaking tgz uploads

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cpuguy83/go-md2man/v2 v2.0.4 h1:wfIWP927BUkWJb2NmU/kNDYIBTh/ziUX91+lVfRxZq4=
@@ -8,10 +9,12 @@ github.com/ericlagergren/decimal v0.0.0-20240411145413-00de7ca16731 h1:R/ZjJpjQK
 github.com/ericlagergren/decimal v0.0.0-20240411145413-00de7ca16731/go.mod h1:M9R1FoZ3y//hwwnJtO51ypFGwm8ZfpxPT/ZLtO1mcgQ=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/urfave/cli/v2 v2.27.2 h1:6e0H+AkS+zDckwPCUrZkKX38mRaau4nL2uipkJpbkcI=

--- a/internal/archive/targz.go
+++ b/internal/archive/targz.go
@@ -17,11 +17,11 @@ type TGZFile struct {
 	Path    string
 }
 
-func ArchiveTGZ(srcFolder string) (*TGZFile, error) {
+func ArchiveTGZ(srcFolder string) (string, error) {
 	destFile := filepath.Clean(srcFolder) + ".tgz"
 	tarGzFile, err := os.Create(destFile)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 	defer tarGzFile.Close()
 
@@ -68,18 +68,7 @@ func ArchiveTGZ(srcFolder string) (*TGZFile, error) {
 		return nil
 	})
 
-	content, err := os.ReadFile(destFile)
-	if err != nil {
-		return nil, err
-	}
-
-	file := &TGZFile{
-		Content: content,
-		Name:    filepath.Base(destFile),
-		Path:    destFile,
-	}
-
-	return file, nil
+	return destFile, nil
 }
 
 func isTGZ(filePath string) (bool, error) {
@@ -131,5 +120,21 @@ func RequireTGZ(srcFolder string) (*TGZFile, error) {
 
 	zap.L().Debug(srcFolder + " is not a tar gzip file. Archiving and compressing now.")
 
-	return ArchiveTGZ(srcFolder)
+	destFile, err := ArchiveTGZ(srcFolder)
+	if err != nil {
+		return nil, err
+	}
+
+	content, err := os.ReadFile(destFile)
+	if err != nil {
+		return nil, err
+	}
+
+	file := &TGZFile{
+		Content: content,
+		Name:    filepath.Base(destFile),
+		Path:    destFile,
+	}
+
+	return file, nil
 }


### PR DESCRIPTION
# Changes
- previously, when zipping a directly, the file contents sent to the API where incorrect because the file was still open. Moved some functionality into a different function to allow go to close the file and flush the writers before trying to get the file contents.