### PR TITLE
Adding value writer for single field exports

### DIFF
--- a/internal/commands/common.go
+++ b/internal/commands/common.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 	"math"
+	"strings"
 
 	"github.com/hathora/ci/internal/output"
 	"github.com/urfave/cli/v3"
@@ -75,6 +76,12 @@ func (c *GlobalConfig) Load(cmd *cli.Command) error {
 		c.Output = output.JSONFormat(cmd.Bool(outputPrettyFlag.Name))
 	case output.Text:
 		c.Output = output.TextFormat()
+	case output.Value:
+		splitValue := strings.Split(outputType, "=")
+		if len(splitValue) != 2 {
+			return fmt.Errorf("invalid value format: %s", outputType)
+		}
+		c.Output = output.ValueFormat(splitValue[1])
 	default:
 		return fmt.Errorf("unsupported output type: %s", outputType)
 	}

--- a/internal/commands/flags.go
+++ b/internal/commands/flags.go
@@ -1,8 +1,6 @@
 package commands
 
 import (
-	"context"
-
 	"github.com/urfave/cli/v3"
 )
 
@@ -12,12 +10,9 @@ var (
 		Aliases:    []string{"o"},
 		Sources:    cli.EnvVars(globalFlagEnvVar("OUTPUT")),
 		Usage:      "the format of the output",
-		Value:      allowedOutputTypes[0],
+		Value:      "json",
 		Persistent: true,
 		Category:   "Global:",
-		Action: func(ctx context.Context, cmd *cli.Command, v string) error {
-			return requireValidEnumValue(v, allowedOutputTypes, "output")
-		},
 	}
 
 	outputPrettyFlag = &cli.BoolFlag{
@@ -90,8 +85,6 @@ var (
 		verbosityFlag,
 		configFlag,
 	}
-
-	allowedOutputTypes = []string{"text", "json"}
 )
 
 var (

--- a/internal/output/types.go
+++ b/internal/output/types.go
@@ -8,6 +8,7 @@ const (
 	UnknownType Type = iota
 	JSON
 	Text
+	Value
 )
 
 func (o Type) String() string {
@@ -22,7 +23,11 @@ func (o Type) String() string {
 }
 
 func ParseOutputType(s string) Type {
-	switch strings.ToLower(s) {
+	lowercaseOutputType := strings.ToLower(s)
+	if strings.HasPrefix(lowercaseOutputType, "value=") {
+		return Value
+	}
+	switch lowercaseOutputType {
 	case "json":
 		return JSON
 	case "text":

--- a/internal/output/value.go
+++ b/internal/output/value.go
@@ -1,0 +1,76 @@
+package output
+
+import (
+	"errors"
+	"fmt"
+	"github.com/hathora/ci/internal/sdk/models/shared"
+	"io"
+	"strings"
+)
+
+func ValueFormat(field string) FormatWriter {
+	return &valueOutputWriter{
+		Field: field,
+	}
+}
+
+type valueOutputWriter struct {
+	Field string
+}
+
+var _ FormatWriter = (*valueOutputWriter)(nil)
+
+func (j *valueOutputWriter) Write(value any, writer io.Writer) error {
+	buildPtr, test := value.(*shared.Build)
+	if test {
+		found, err := getBuildValuePtr(buildPtr, j.Field)
+		if err != nil {
+			return err
+		}
+		_, err = fmt.Fprintf(writer, "%v\n", found)
+		return err
+	}
+
+	build, test := value.(shared.Build)
+	if test {
+		found, err := getBuildValue(build, j.Field)
+		if err != nil {
+			return err
+		}
+		_, err = fmt.Fprintf(writer, "%v\n", found)
+		return err
+	}
+
+	builds, test := value.([]shared.Build)
+	if test {
+		for _, b := range builds {
+			found, err := getBuildValue(b, j.Field)
+			if err != nil {
+				return err
+			}
+			_, err = fmt.Fprintf(writer, "%v\n", found)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	// default to just writing the text
+	_, err := fmt.Fprintf(writer, "%v\n", value)
+	return err
+}
+
+func getBuildValuePtr(build *shared.Build, key string) (any, error) {
+	return getBuildValue(*build, key)
+}
+
+func getBuildValue(build shared.Build, key string) (any, error) {
+	switch strings.ToLower(key) {
+	case "buildid":
+		return build.BuildID, nil
+	default:
+		return nil, errors.New(fmt.Sprintf("key %s not supported", key))
+	}
+}


### PR DESCRIPTION
# Changes
- Added a new writer to return only a single field to stdout
- This allows us to chain commands together by returning the necessary field from one command to another (like the build ID)
- The Value writer defaults to writing the whole response to stdout if the response cannot be typed

## Examples

An example of this in action would be to chain the output of the create command, to the deploy command. Something like the following

```
# the only output to stdout is the build ID from the create build response.
buildId="$(go run cmd/run.go build create --build-tag test-build-tag --file ./test-build.tgz -o value=buildid)"

go run cmd/run.go deployment create-deployment -b "$buildId" ...otherInputs
```