### PR TITLE
Initial prelaunch cleanup pass

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,6 @@ FROM gcr.io/distroless/static-debian12:nonroot
 ARG TARGETOS
 ARG TARGETARCH
 
-COPY --from=builder /app/bin/hathora-ci-${TARGETOS}-${TARGETARCH} /hathora-ci
+COPY --from=builder /app/bin/hathora-${TARGETOS}-${TARGETARCH} /hathora
 
 ENTRYPOINT ["/hathora-ci"]

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ BUILD_VERSION ?= $(shell git describe --always --dirty)
 
 .PHONY: all
 all: build
+
 ##@ Build
 .PHONY: clean
 clean: ## Delete all built binaries.
@@ -18,7 +19,7 @@ clean: ## Delete all built binaries.
 build: ## Build the command binaries.
 	CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build \
-        -o bin/hathora-ci-${TARGETOS}-${TARGETARCH} \
+        -o bin/hathora-${TARGETOS}-${TARGETARCH} \
         -ldflags "-X 'github.com/hathora/ci/internal/commands.BuildVersion=${BUILD_VERSION}'" \
         cmd/run.go
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	"log"
+	"fmt"
 	"os"
 
 	"github.com/hathora/ci/internal/commands"
@@ -10,6 +10,7 @@ import (
 
 func main() {
 	if err := commands.App().Run(context.Background(), os.Args); err != nil {
-		log.Fatal(err)
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -6,11 +6,11 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/dustin/go-humanize v1.0.1
 	github.com/ericlagergren/decimal v0.0.0-20240411145413-00de7ca16731
+	github.com/h2non/filetype v1.1.3
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00
 	github.com/stretchr/testify v1.9.0
 	github.com/urfave/cli/v3 v3.0.0-alpha9
-	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -19,4 +19,5 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/xrash/smetrics v0.0.0-20240312152122-5f08fbb34913 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,3 @@
-github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -7,17 +6,16 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/ericlagergren/decimal v0.0.0-20240411145413-00de7ca16731 h1:R/ZjJpjQKsZ6L/+Gf9WHbt31GG8NMVcpRqUE+1mMIyo=
 github.com/ericlagergren/decimal v0.0.0-20240411145413-00de7ca16731/go.mod h1:M9R1FoZ3y//hwwnJtO51ypFGwm8ZfpxPT/ZLtO1mcgQ=
+github.com/h2non/filetype v1.1.3 h1:FKkx9QbD7HR/zjK1Ia5XiBsq9zdLi5Kf3zGyFTAFkGg=
+github.com/h2non/filetype v1.1.3/go.mod h1:319b3zT68BvV+WRj7cwy856M2ehB3HqNOt6sy1HndBY=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
-github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 h1:n6/2gBQ3RWajuToeY6ZtZTIKv2v7ThUy5KKusIT0yc0=
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00/go.mod h1:Pm3mSP3c5uWn86xMLZ5Sa7JB9GsEZySvHYXCTK4E9q4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/urfave/cli-altsrc/v3 v3.0.0-alpha2/go.mod h1:Q79oyIY/z4jtzIrKEK6MUeWC7/szGr46x4QdOaOAIWc=
 github.com/urfave/cli/v3 v3.0.0-alpha9 h1:P0RMy5fQm1AslQS+XCmy9UknDXctOmG/q/FZkUFnJSo=
 github.com/urfave/cli/v3 v3.0.0-alpha9/go.mod h1:0kK/RUFHyh+yIKSfWxwheGndfnrvYSmYFVeKCh03ZUc=
 github.com/xrash/smetrics v0.0.0-20240312152122-5f08fbb34913 h1:+qGGcbkzsfDQNPPe9UDgpxAWQrhbbBXOYJFQDq/dtJw=

--- a/install.ps1
+++ b/install.ps1
@@ -19,8 +19,6 @@ if ($arch -eq "AMD64") {
 # Set the download URL for the Windows binary based on the architecture
 $downloadUrl = "https://github.com/$repoOwner/$repoName/releases/download/$latestRelease/$binaryName-windows-$arch"
 
-echo $downloadUrl
-
 # Set the install directory
 $installDir = "$env:LOCALAPPDATA\Microsoft\WindowsApps"
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,4 +1,4 @@
-$repoOwner = "hathora-ci"
+$repoOwner = "hathora"
 $repoName = "ci"
 $binaryName = "hathora"
 
@@ -17,7 +17,9 @@ if ($arch -eq "AMD64") {
 }
 
 # Set the download URL for the Windows binary based on the architecture
-$downloadUrl = "https://github.com/$repoOwner/$repoName/releases/download/$latestRelease/$binaryName-windows-$arch.exe"
+$downloadUrl = "https://github.com/$repoOwner/$repoName/releases/download/$latestRelease/$binaryName-windows-$arch"
+
+echo $downloadUrl
 
 # Set the install directory
 $installDir = "$env:LOCALAPPDATA\Microsoft\WindowsApps"

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@ set -e
 
 REPO_OWNER="hathora"
 REPO_NAME="ci"
-BINARY_NAME="hathora-ci"
+BINARY_NAME="hathora"
 
 # Get the latest release tag from GitHub
 LATEST_RELEASE=$(curl -s https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases/latest | grep "tag_name" | cut -d '"' -f 4)

--- a/internal/archive/targz.go
+++ b/internal/archive/targz.go
@@ -25,7 +25,7 @@ func getIgnoreMatchers(srcFolder string, filepaths ...string) ([]gitignore.Ignor
 	for _, path := range filepaths {
 		matcher, err := gitignore.NewGitIgnore(filepath.Join(srcFolder, path), ".")
 		if err != nil {
-			zap.L().Debug("Did not file a " + path + " file. Skipping.")
+			zap.L().Debug("Could not find a " + path + " file. " + path + " matcher will not be used.")
 			continue
 		}
 
@@ -64,7 +64,8 @@ func ArchiveTGZ(srcFolder string) (string, error) {
 	ignoreMatchers, err := getIgnoreMatchers(
 		srcFolder,
 		".dockerignore",
-		".gitignore")
+		".gitignore",
+	)
 
 	if err != nil {
 		return "", err

--- a/internal/commands/altsrc/filesource.go
+++ b/internal/commands/altsrc/filesource.go
@@ -9,7 +9,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func File(fileFlag string, valuePath string) cli.ValueSource {
+func ConfigFile(fileFlag string, valuePath string) cli.ValueSource {
 	return &fileValueSource{
 		fileFlag:  fileFlag,
 		valuePath: valuePath,

--- a/internal/commands/app.go
+++ b/internal/commands/app.go
@@ -50,6 +50,7 @@ func App() *cli.Command {
 		},
 		Commands: []*cli.Command{
 			Build,
+			Deploy,
 			Deployment,
 		},
 		After: func(ctx context.Context, c *cli.Command) error {

--- a/internal/commands/app.go
+++ b/internal/commands/app.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"os"
 
+	"github.com/urfave/cli/v3"
+
 	"github.com/hathora/ci/internal/commands/altsrc"
 	"github.com/hathora/ci/internal/setup"
-	"github.com/urfave/cli/v3"
 )
 
 var (
@@ -21,8 +22,7 @@ func App() *cli.Command {
 
 	var cleanup []func()
 	return &cli.Command{
-		Name:                   "hathora-ci",
-		Aliases:                []string{"ci"},
+		Name:                   "hathora",
 		EnableShellCompletion:  true,
 		Suggest:                true,
 		UseShortOptionHandling: true,

--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -3,17 +3,18 @@ package commands
 import (
 	"context"
 	"fmt"
-	"github.com/hathora/ci/internal/output"
 	"os"
+
+	"github.com/urfave/cli/v3"
+	"go.uber.org/zap"
 
 	"github.com/hathora/ci/internal/archive"
 	"github.com/hathora/ci/internal/commands/altsrc"
+	"github.com/hathora/ci/internal/output"
 	"github.com/hathora/ci/internal/sdk"
 	"github.com/hathora/ci/internal/sdk/models/operations"
 	"github.com/hathora/ci/internal/sdk/models/shared"
 	"github.com/hathora/ci/internal/setup"
-	"github.com/urfave/cli/v3"
-	"go.uber.org/zap"
 )
 
 var Build = &cli.Command{
@@ -158,8 +159,9 @@ var (
 		Name:    "build-id",
 		Aliases: []string{"b"},
 		Sources: cli.NewValueSourceChain(
+			cli.Files("/dev/stdin").Chain[0],
 			cli.EnvVar(buildFlagEnvVar("ID")),
-			altsrc.File(configFlag.Name, "build.id"),
+			altsrc.ConfigFile(configFlag.Name, "build.id"),
 		),
 		Usage:      "the ID of the build in Hathora",
 		Persistent: true,
@@ -170,7 +172,7 @@ var (
 		Aliases: []string{"bt"},
 		Sources: cli.NewValueSourceChain(
 			cli.EnvVar(buildFlagEnvVar("TAG")),
-			altsrc.File(configFlag.Name, "build.tag"),
+			altsrc.ConfigFile(configFlag.Name, "build.tag"),
 		),
 		Usage: "tag to associate an external version with a build",
 	}
@@ -180,7 +182,7 @@ var (
 		Aliases: []string{"f"},
 		Sources: cli.NewValueSourceChain(
 			cli.EnvVar(buildFlagEnvVar("FILE")),
-			altsrc.File(configFlag.Name, "build.file"),
+			altsrc.ConfigFile(configFlag.Name, "build.file"),
 		),
 		Usage:    "filepath of the built game server binary or archive",
 		Required: true,

--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -112,6 +112,7 @@ var Build = &cli.Command{
 					return fmt.Errorf("failed to run build: %w", err)
 				}
 
+				zap.L().Debug("streaming build output to console...")
 				err = output.StreamOutput(runRes.Stream, os.Stderr)
 
 				if err != nil {

--- a/internal/commands/build_test.go
+++ b/internal/commands/build_test.go
@@ -18,7 +18,7 @@ func Test_BuildCommands_HelpText(t *testing.T) {
 	t.Parallel()
 
 	app := commands.App()
-	err := app.Run(context.Background(), []string{"ci", "build", "--help"})
+	err := app.Run(context.Background(), []string{"hathora", "build", "--help"})
 	assert.Nil(t, err, "command returned an error")
 }
 
@@ -97,8 +97,8 @@ func Test_Integration_BuildCommands_Happy(t *testing.T) {
 			},
 		},
 		{
-			name:           "create a build",
-			command:        "create --build-tag test-build-tag --file TODO",
+			name:    "create a build",
+			command: "create --build-tag test-build-tag --file TODO",
 			// TODO setup the file input and mocks for multiple http responses
 			skip:           true,
 			responseStatus: http.StatusCreated,
@@ -154,7 +154,7 @@ func Test_Integration_BuildCommands_Happy(t *testing.T) {
 			h := mock.Hathora(t, mock.RespondsWithStatus(tt.responseStatus), mock.RespondsWithJSON([]byte(tt.responseBody)))
 			app := commands.App()
 			staticArgs := []string{
-				"ci",
+				"hathora",
 				"--app-id",
 				"test-app-id",
 				"--token",
@@ -253,7 +253,7 @@ func Test_Integration_BuildCommands_GlobalArgs(t *testing.T) {
 			h := mock.Hathora(t, mock.RespondsWithStatus(tt.responseStatus), mock.RespondsWithJSON([]byte(tt.responseBody)))
 			app := commands.App()
 			staticArgs := []string{
-				"ci",
+				"hathora",
 				"--hathora-cloud-endpoint",
 				h.Endpoint,
 			}

--- a/internal/commands/build_test.go
+++ b/internal/commands/build_test.go
@@ -155,6 +155,7 @@ func Test_Integration_BuildCommands_Happy(t *testing.T) {
 			app := commands.App()
 			staticArgs := []string{
 				"hathora",
+				"-vvv",
 				"--app-id",
 				"test-app-id",
 				"--token",
@@ -254,6 +255,7 @@ func Test_Integration_BuildCommands_GlobalArgs(t *testing.T) {
 			app := commands.App()
 			staticArgs := []string{
 				"hathora",
+				"-vvv",
 				"--hathora-cloud-endpoint",
 				h.Endpoint,
 			}

--- a/internal/commands/build_test.go
+++ b/internal/commands/build_test.go
@@ -192,7 +192,7 @@ func Test_Integration_BuildCommands_GlobalArgs(t *testing.T) {
 	}{
 		{
 			name:           "use global args after domain-level command",
-			command:        "build --app-id test-app-id --token test-token -vvv info --build-id 1",
+			command:        "build --app-id test-app-id --token test-token info --build-id 1",
 			responseStatus: http.StatusOK,
 			responseBody: `{
 				"buildTag": "0.1.14-14c793",
@@ -220,7 +220,7 @@ func Test_Integration_BuildCommands_GlobalArgs(t *testing.T) {
 		},
 		{
 			name:           "use global args after action-level command",
-			command:        "build info --build-id 1 --app-id test-app-id --token test-token -vvv",
+			command:        "build info --build-id 1 --app-id test-app-id --token test-token",
 			responseStatus: http.StatusOK,
 			responseBody: `{
 				"buildTag": "0.1.14-14c793",

--- a/internal/commands/common.go
+++ b/internal/commands/common.go
@@ -93,7 +93,9 @@ func (c *GlobalConfig) Load(cmd *cli.Command) error {
 		return fmt.Errorf("unsupported output type: %s", outputType)
 	}
 
-	verboseCount := cmd.Count(verboseFlag.Name)
+	// we subtract 1 because the flag is counted an additional time for the
+	// --verbose alias
+	verboseCount := cmd.Count(verboseFlag.Name) - 1
 	verbosity := cmd.Int(verbosityFlag.Name)
 	c.Verbosity = int(math.Max(float64(verbosity), float64(verboseCount)))
 	c.Log = zap.L().With(zap.String("app.id", appID))

--- a/internal/commands/common.go
+++ b/internal/commands/common.go
@@ -5,16 +5,16 @@ import (
 	"fmt"
 	"go/version"
 	"math"
+	"net/http"
 	"strings"
 	"time"
 
-	"net/http"
-
 	"github.com/dustin/go-humanize"
-	"github.com/hathora/ci/internal/output"
-	"github.com/hathora/ci/internal/sdk/models/shared"
 	"github.com/urfave/cli/v3"
 	"go.uber.org/zap"
+
+	"github.com/hathora/ci/internal/output"
+	"github.com/hathora/ci/internal/sdk/models/shared"
 )
 
 var (

--- a/internal/commands/deploy.go
+++ b/internal/commands/deploy.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/hathora/ci/internal/sdk"
 	"github.com/hathora/ci/internal/sdk/models/shared"
@@ -33,10 +34,6 @@ var Deploy = &cli.Command{
 		if err != nil {
 			return err
 		}
-		createdBuild, err := doBuildCreate(ctx, deploy.CreateBuildConfig)
-		if err != nil {
-			return err
-		}
 
 		useLatest := cmd.Bool(fromLatestFlag.Name)
 		if useLatest {
@@ -49,6 +46,11 @@ var Deploy = &cli.Command{
 		}
 
 		if err := deploy.Validate(); err != nil {
+			return err
+		}
+
+		createdBuild, err := doBuildCreate(ctx, deploy.CreateBuildConfig)
+		if err != nil {
 			return err
 		}
 
@@ -198,10 +200,10 @@ func (c *DeployConfig) Validate() error {
 
 	if c.RequestedMemoryMB != (c.RequestedCPU * memoryMBPerCPU) {
 		err = errors.Join(err,
-			fmt.Errorf("invalid memory: %f and cpu: %f requested-memory-mb must be a %f:1 ratio to requested-cpu",
-				c.RequestedMemoryMB,
-				c.RequestedCPU,
-				memoryMBPerCPU,
+			fmt.Errorf("invalid memory: %s and cpu: %s requested-memory-mb must be a %s:1 ratio to requested-cpu",
+				strconv.FormatFloat(c.RequestedMemoryMB, 'f', -1, 64),
+				strconv.FormatFloat(c.RequestedCPU, 'f', -1, 64),
+				strconv.FormatFloat(memoryMBPerCPU, 'f', -1, 64),
 			))
 	}
 

--- a/internal/commands/deploy.go
+++ b/internal/commands/deploy.go
@@ -1,0 +1,217 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/hathora/ci/internal/sdk"
+	"github.com/hathora/ci/internal/sdk/models/shared"
+	"github.com/hathora/ci/internal/shorthand"
+	"github.com/urfave/cli/v3"
+)
+
+var Deploy = &cli.Command{
+	Name:  "deploy",
+	Usage: "create a build and a deployment in a combined flow",
+	Flags: subcommandFlags(
+		buildTagFlag,
+		fileFlag,
+		fromLatestFlag,
+		roomsPerProcessFlag,
+		transportTypeFlag,
+		containerPortFlag,
+		requestedMemoryFlag,
+		requestedCPUFlag,
+		additionalContainerPortsFlag,
+		envVarsFlag,
+		idleTimeoutFlag,
+	),
+	Action: func(ctx context.Context, cmd *cli.Command) error {
+		deploy, err := DeployConfigFrom(cmd)
+		if err != nil {
+			return err
+		}
+		createdBuild, err := doBuildCreate(ctx, deploy.CreateBuildConfig)
+		if err != nil {
+			return err
+		}
+
+		useLatest := cmd.Bool(fromLatestFlag.Name)
+		if useLatest {
+			res, err := deploy.SDK.DeploymentV2.GetLatestDeployment(ctx, deploy.AppID)
+			if err != nil {
+				return fmt.Errorf("unable to retrieve latest deployment: %w", err)
+			}
+
+			deploy.Merge(res.DeploymentV2)
+		}
+
+		if err := deploy.Validate(); err != nil {
+			return err
+		}
+
+		res, err := deploy.SDK.DeploymentV2.CreateDeployment(
+			ctx,
+			createdBuild.BuildID,
+			shared.DeploymentConfigV2{
+				IdleTimeoutEnabled:       *deploy.IdleTimeoutEnabled,
+				RoomsPerProcess:          deploy.RoomsPerProcess,
+				TransportType:            deploy.TransportType,
+				ContainerPort:            deploy.ContainerPort,
+				RequestedMemoryMB:        deploy.RequestedMemoryMB,
+				RequestedCPU:             deploy.RequestedCPU,
+				AdditionalContainerPorts: deploy.AdditionalContainerPorts,
+				Env:                      deploy.Env,
+			},
+			deploy.AppID,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to create a deployment: %w", err)
+		}
+
+		return deploy.Output.Write(res.DeploymentV2, os.Stdout)
+	},
+}
+
+var (
+	deployConfigKey = "commands.Deploy.DI"
+)
+
+type DeployConfig struct {
+	*CreateBuildConfig
+	IdleTimeoutEnabled       *bool
+	RoomsPerProcess          int
+	TransportType            shared.TransportType
+	ContainerPort            int
+	RequestedMemoryMB        float64
+	RequestedCPU             float64
+	AdditionalContainerPorts []shared.ContainerPort
+	Env                      []shared.DeploymentConfigV2Env
+}
+
+var _ LoadableConfig = (*DeployConfig)(nil)
+
+func (c *DeployConfig) Load(cmd *cli.Command) error {
+	build, err := CreateBuildConfigFrom(cmd)
+	if err != nil {
+		return err
+	}
+	c.CreateBuildConfig = build
+
+	c.RoomsPerProcess = int(cmd.Int(roomsPerProcessFlag.Name))
+	c.TransportType = shared.TransportType(cmd.String(transportTypeFlag.Name))
+	c.ContainerPort = int(cmd.Int(containerPortFlag.Name))
+	c.RequestedMemoryMB = cmd.Float(requestedMemoryFlag.Name)
+	c.RequestedCPU = cmd.Float(requestedCPUFlag.Name)
+	c.IdleTimeoutEnabled = sdk.Bool(cmd.Bool(idleTimeoutFlag.Name))
+
+	addlPorts := cmd.StringSlice(additionalContainerPortsFlag.Name)
+	parsedAddlPorts, err := parseContainerPorts(addlPorts)
+	if err != nil {
+		return fmt.Errorf("invalid additional container ports: %w", err)
+	}
+	c.AdditionalContainerPorts = parsedAddlPorts
+
+	envVars := cmd.StringSlice(envVarsFlag.Name)
+	env, err := parseEnvVars(envVars)
+	if err != nil {
+		return fmt.Errorf("invalid environment variables: %w", err)
+	}
+	c.Env = env
+
+	return nil
+}
+
+func (c *DeployConfig) Merge(latest *shared.DeploymentV2) {
+	if latest == nil {
+		return
+	}
+
+	if c.IdleTimeoutEnabled == nil {
+		c.IdleTimeoutEnabled = &latest.IdleTimeoutEnabled
+	}
+
+	if c.RoomsPerProcess == 0 {
+		c.RoomsPerProcess = latest.RoomsPerProcess
+	}
+
+	if c.TransportType == "" {
+		c.TransportType = latest.DefaultContainerPort.TransportType
+	}
+
+	if c.ContainerPort == 0 {
+		c.ContainerPort = latest.DefaultContainerPort.Port
+	}
+
+	if c.RequestedMemoryMB == 0 {
+		c.RequestedMemoryMB = latest.RequestedMemoryMB
+	}
+
+	if c.RequestedCPU == 0 {
+		c.RequestedCPU = latest.RequestedCPU
+	}
+
+	if len(c.AdditionalContainerPorts) == 0 {
+		c.AdditionalContainerPorts = latest.AdditionalContainerPorts
+	}
+
+	if len(c.Env) == 0 {
+		c.Env = shorthand.MapEnvToEnvConfig(latest.Env)
+	}
+}
+
+func (c *DeployConfig) Validate() error {
+	var err error
+
+	if c.IdleTimeoutEnabled == nil {
+		err = errors.Join(err, fmt.Errorf("idle timeout enabled is required"))
+	}
+
+	if c.RoomsPerProcess == 0 {
+		err = errors.Join(err, fmt.Errorf("rooms per process is required"))
+	}
+
+	err = errors.Join(err, requireIntInRange(c.RoomsPerProcess, minRoomsPerProcess, maxRoomsPerProcess, roomsPerProcessFlag.Name))
+
+	if c.TransportType == "" {
+		err = errors.Join(err, fmt.Errorf("transport type is required"))
+	}
+	err = errors.Join(err, requireValidEnumValue(c.TransportType, allowedTransportTypes, transportTypeFlag.Name))
+
+	if c.ContainerPort == 0 {
+		err = errors.Join(err, fmt.Errorf("container port is required"))
+	}
+	err = errors.Join(err, requireIntInRange(c.ContainerPort, minPort, maxPort, containerPortFlag.Name))
+
+	if c.RequestedMemoryMB == 0 {
+		err = errors.Join(err, fmt.Errorf("requested memory is required"))
+	}
+	err = errors.Join(err, requireFloatInRange(c.RequestedMemoryMB, minMemoryMB, maxMemoryMB, requestedMemoryFlag.Name))
+	if c.RequestedCPU == 0 {
+		err = errors.Join(err, fmt.Errorf("requested CPU is required"))
+	}
+
+	err = errors.Join(err, requireFloatInRange(c.RequestedCPU, minCPU, maxCPU, requestedCPUFlag.Name))
+	err = errors.Join(err, requireMaxDecimals(c.RequestedCPU, maxCPUDecimalPlaces, requestedCPUFlag.Name))
+
+	if c.RequestedMemoryMB != (c.RequestedCPU * memoryMBPerCPU) {
+		err = errors.Join(err,
+			fmt.Errorf("invalid memory: %f and cpu: %f requested-memory-mb must be a %f:1 ratio to requested-cpu",
+				c.RequestedMemoryMB,
+				c.RequestedCPU,
+				memoryMBPerCPU,
+			))
+	}
+
+	return err
+}
+
+func (c *DeployConfig) New() LoadableConfig {
+	return &DeployConfig{}
+}
+
+func DeployConfigFrom(cmd *cli.Command) (*DeployConfig, error) {
+	return ConfigFromCLI[*DeployConfig](deployConfigKey, cmd)
+}

--- a/internal/commands/deployment.go
+++ b/internal/commands/deployment.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/urfave/cli/v3"
 	"go.uber.org/zap"
@@ -481,10 +482,10 @@ func (c *CreateDeploymentConfig) Validate() error {
 
 	if c.RequestedMemoryMB != (c.RequestedCPU * memoryMBPerCPU) {
 		err = errors.Join(err,
-			fmt.Errorf("invalid memory: %f and cpu: %f requested-memory-mb must be a %f:1 ratio to requested-cpu",
-				c.RequestedMemoryMB,
-				c.RequestedCPU,
-				memoryMBPerCPU,
+			fmt.Errorf("invalid memory: %s and cpu: %s requested-memory-mb must be a %s:1 ratio to requested-cpu",
+				strconv.FormatFloat(c.RequestedMemoryMB, 'f', -1, 64),
+				strconv.FormatFloat(c.RequestedCPU, 'f', -1, 64),
+				strconv.FormatFloat(memoryMBPerCPU, 'f', -1, 64),
 			))
 	}
 

--- a/internal/commands/deployment.go
+++ b/internal/commands/deployment.go
@@ -178,6 +178,7 @@ var (
 			cli.EnvVar(deploymentEnvVar("IDLE_TIMEOUT_ENABLED")),
 			altsrc.ConfigFile(configFlag.Name, "deployment.idle-timeout-enabled"),
 		),
+		Value:      false,
 		Usage:      "option to shut down processes that have had no new connections or rooms for five minutes",
 		Persistent: true,
 	}

--- a/internal/commands/deployment.go
+++ b/internal/commands/deployment.go
@@ -4,16 +4,17 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/hathora/ci/internal/commands/altsrc"
 	"os"
 	"strconv"
 
+	"github.com/urfave/cli/v3"
+	"go.uber.org/zap"
+
+	"github.com/hathora/ci/internal/commands/altsrc"
 	"github.com/hathora/ci/internal/sdk"
 	"github.com/hathora/ci/internal/sdk/models/shared"
 	"github.com/hathora/ci/internal/setup"
 	"github.com/hathora/ci/internal/shorthand"
-	"github.com/urfave/cli/v3"
-	"go.uber.org/zap"
 )
 
 var (
@@ -175,7 +176,7 @@ var (
 		Name: "idle-timeout-enabled",
 		Sources: cli.NewValueSourceChain(
 			cli.EnvVar(deploymentEnvVar("IDLE_TIMEOUT_ENABLED")),
-			altsrc.File(configFlag.Name, "deployment.idle-timeout-enabled"),
+			altsrc.ConfigFile(configFlag.Name, "deployment.idle-timeout-enabled"),
 		),
 		Usage:      "option to shut down processes that have had no new connections or rooms for five minutes",
 		Persistent: true,
@@ -185,7 +186,7 @@ var (
 		Name: "rooms-per-process",
 		Sources: cli.NewValueSourceChain(
 			cli.EnvVar(deploymentEnvVar("ROOMS_PER_PROCESS")),
-			altsrc.File(configFlag.Name, "deployment.rooms-per-process"),
+			altsrc.ConfigFile(configFlag.Name, "deployment.rooms-per-process"),
 		),
 		Usage:      "how many rooms can be scheduled in a process",
 		Persistent: true,
@@ -195,7 +196,7 @@ var (
 		Name: "transport-type",
 		Sources: cli.NewValueSourceChain(
 			cli.EnvVar(deploymentEnvVar("TRANSPORT_TYPE")),
-			altsrc.File(configFlag.Name, "deployment.transport-type"),
+			altsrc.ConfigFile(configFlag.Name, "deployment.transport-type"),
 		),
 		Usage:      "the underlying communication protocol to the exposed port",
 		Persistent: true,
@@ -205,17 +206,17 @@ var (
 		Name: "container-port",
 		Sources: cli.NewValueSourceChain(
 			cli.EnvVar(deploymentEnvVar("CONTAINER_PORT")),
-			altsrc.File(configFlag.Name, "deployment.container-port"),
+			altsrc.ConfigFile(configFlag.Name, "deployment.container-port"),
 		),
 		Usage:      "default server port",
 		Persistent: true,
 	}
 
 	additionalContainerPortsFlag = &cli.StringSliceFlag{
-		Name:    "additional-container-ports",
+		Name: "additional-container-ports",
 		Sources: cli.NewValueSourceChain(
 			cli.EnvVar(deploymentEnvVar("ADDITIONAL_CONTAINER_PORTS")),
-			altsrc.File(configFlag.Name, "deployment.additional-container-ports"),
+			altsrc.ConfigFile(configFlag.Name, "deployment.additional-container-ports"),
 		),
 		Usage: "additional server ports",
 	}
@@ -230,7 +231,7 @@ var (
 		Name: "requested-memory-mb",
 		Sources: cli.NewValueSourceChain(
 			cli.EnvVar(deploymentEnvVar("REQUESTED_MEMORY_MB")),
-			altsrc.File(configFlag.Name, "deployment.requested-memory-mb"),
+			altsrc.ConfigFile(configFlag.Name, "deployment.requested-memory-mb"),
 		),
 		Usage:      "the amount of memory allocated to your process in MB",
 		Persistent: true,
@@ -240,7 +241,7 @@ var (
 		Name: "requested-cpu",
 		Sources: cli.NewValueSourceChain(
 			cli.EnvVar(deploymentEnvVar("REQUESTED_CPU")),
-			altsrc.File(configFlag.Name, "deployment.requested-cpu"),
+			altsrc.ConfigFile(configFlag.Name, "deployment.requested-cpu"),
 		),
 		Usage:      "the number of cores allocated to your process",
 		Persistent: true,

--- a/internal/commands/deployment_test.go
+++ b/internal/commands/deployment_test.go
@@ -22,7 +22,7 @@ func Test_DeploymentCommands_HelpText(t *testing.T) {
 	t.Parallel()
 
 	app := commands.App()
-	err := app.Run(context.Background(), []string{"ci", "deployment", "--help"})
+	err := app.Run(context.Background(), []string{"hathora", "deployment", "--help"})
 	assert.Nil(t, err, "command returned an error")
 }
 
@@ -219,7 +219,7 @@ func Test_Integration_DeploymentCommands_Happy(t *testing.T) {
 			h := mock.Hathora(t, mock.RespondsWithStatus(tt.responseStatus), mock.RespondsWithJSON([]byte(tt.responseBody)))
 			app := commands.App()
 			staticArgs := []string{
-				"ci",
+				"hathora",
 				"--app-id",
 				"test-app-id",
 				"--token",
@@ -510,7 +510,7 @@ func Test_Integration_DeploymentCommands_CreateFromLatest(t *testing.T) {
 			h := mock.Hathora(t, opts...)
 			app := commands.App()
 			staticArgs := []string{
-				"ci",
+				"hathora",
 				"--app-id",
 				"test-app-id",
 				"--token",
@@ -625,7 +625,7 @@ func Test_Integration_DeploymentCommands_CreateFromLatestWithBadMemToCPURatio(t 
 			h := mock.Hathora(t, opts...)
 			app := commands.App()
 			staticArgs := []string{
-				"ci",
+				"hathora",
 				"--app-id",
 				"test-app-id",
 				"--token",

--- a/internal/commands/deployment_test.go
+++ b/internal/commands/deployment_test.go
@@ -220,6 +220,7 @@ func Test_Integration_DeploymentCommands_Happy(t *testing.T) {
 			app := commands.App()
 			staticArgs := []string{
 				"hathora",
+				"-vvv",
 				"--app-id",
 				"test-app-id",
 				"--token",
@@ -511,6 +512,7 @@ func Test_Integration_DeploymentCommands_CreateFromLatest(t *testing.T) {
 			app := commands.App()
 			staticArgs := []string{
 				"hathora",
+				"-vvv",
 				"--app-id",
 				"test-app-id",
 				"--token",
@@ -626,6 +628,7 @@ func Test_Integration_DeploymentCommands_CreateFromLatestWithBadMemToCPURatio(t 
 			app := commands.App()
 			staticArgs := []string{
 				"hathora",
+				"-vvv",
 				"--app-id",
 				"test-app-id",
 				"--token",

--- a/internal/commands/flags.go
+++ b/internal/commands/flags.go
@@ -1,9 +1,9 @@
 package commands
 
 import (
-	"github.com/hathora/ci/internal/commands/altsrc"
-
 	"github.com/urfave/cli/v3"
+
+	"github.com/hathora/ci/internal/commands/altsrc"
 )
 
 var (
@@ -12,10 +12,10 @@ var (
 		Aliases: []string{"o"},
 		Sources: cli.NewValueSourceChain(
 			cli.EnvVar(globalFlagEnvVar("OUTPUT")),
-			altsrc.File(configFlag.Name, "global.output"),
+			altsrc.ConfigFile(configFlag.Name, "global.output"),
 		),
-		Usage:      "the format of the output",
-		Value:      "json",
+		Usage:      "the format of the output. Supported values: (json, text, value=buildId)",
+		Value:      "text",
 		Persistent: true,
 		Category:   "Global:",
 	}
@@ -33,7 +33,7 @@ var (
 		Aliases: []string{"a"},
 		Sources: cli.NewValueSourceChain(
 			cli.EnvVar(buildFlagEnvVar("APP_ID")),
-			altsrc.File(configFlag.Name, "app.id"),
+			altsrc.ConfigFile(configFlag.Name, "app.id"),
 		),
 		Usage:      "the ID of the app in Hathora",
 		Category:   "Global:",
@@ -52,7 +52,7 @@ var (
 		Name: "verbosity",
 		Sources: cli.NewValueSourceChain(
 			cli.EnvVar(globalFlagEnvVar("VERBOSITY")),
-			altsrc.File(configFlag.Name, "global.verbosity"),
+			altsrc.ConfigFile(configFlag.Name, "global.verbosity"),
 		),
 		Usage:      "set the logging verbosity level",
 		Value:      0,
@@ -64,7 +64,7 @@ var (
 		Name: "hathora-cloud-endpoint",
 		Sources: cli.NewValueSourceChain(
 			cli.EnvVar(globalFlagEnvVar("CLOUD_ENDPOINT")),
-			altsrc.File(configFlag.Name, "global.cloud-endpoint"),
+			altsrc.ConfigFile(configFlag.Name, "global.cloud-endpoint"),
 		),
 		Usage:       "override the default API base url",
 		DefaultText: "https://api.hathora.dev",

--- a/internal/commands/flags.go
+++ b/internal/commands/flags.go
@@ -32,7 +32,7 @@ var (
 		Name:    "app-id",
 		Aliases: []string{"a"},
 		Sources: cli.NewValueSourceChain(
-			cli.EnvVar(buildFlagEnvVar("APP_ID")),
+			cli.EnvVar(globalFlagEnvVar("APP_ID")),
 			altsrc.ConfigFile(configFlag.Name, "app.id"),
 		),
 		Usage:      "the ID of the app in Hathora",

--- a/internal/httputil/headers.go
+++ b/internal/httputil/headers.go
@@ -11,7 +11,15 @@ type contentTypeRoundTripper struct {
 // RoundTrip This is a stop gap until speakeasy respects that empty content type == octet-stream
 func (c *contentTypeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	res, err := c.underlying.RoundTrip(req)
-	if res.Header.Get("content-type") == ""  {
+	if err != nil {
+		return res, err
+	}
+
+	if res.Header == nil {
+		return res, err
+	}
+
+	if res.Header.Get("content-type") == "" {
 		res.Header.Set("content-type", "application/octet-stream")
 	}
 

--- a/internal/httputil/logging.go
+++ b/internal/httputil/logging.go
@@ -82,11 +82,21 @@ func (h *loggingRoundTripper) afterSuccess(res *http.Response) {
 }
 
 func (h *loggingRoundTripper) afterError(res *http.Response, err error) {
+	method := "unknown"
+	url := "unknown"
+	status := 0
+
+	if res != nil && res.Request != nil {
+		method = res.Request.Method
+		url = res.Request.URL.String()
+		status = res.StatusCode
+	}
+
 	h.logger.Debug(
 		"response",
-		zap.String("http.method", res.Request.Method),
-		zap.Stringer("http.url", res.Request.URL),
-		zap.Int("http.status", res.StatusCode),
+		zap.String("http.method", method),
+		zap.String("http.url", url),
+		zap.Int("http.status", status),
 		zap.Error(err),
 	)
 }

--- a/internal/httputil/logging.go
+++ b/internal/httputil/logging.go
@@ -36,67 +36,87 @@ func LoggingRoundTripper(underlying http.RoundTripper, verbosity int) http.Round
 }
 
 func (h *loggingRoundTripper) beforeRequest(req *http.Request) {
-	// if the verbosity is all the way up, dump outgoing request bodies to logs
-	if h.verbosity > 2 {
-		reqDump, err := httputil.DumpRequestOut(req, true)
-		if err == nil {
-			h.logger.Debug(
-				"request",
-				zap.String("http.method", req.Method),
-				zap.Stringer("http.url", req.URL),
-				zap.String("http.request.dump", string(reqDump)),
-			)
-			return
-		}
-	}
+	go func() {
+		// if the verbosity is all the way up, dump outgoing request bodies to logs
+		if h.verbosity > 2 {
+			var reqDump []byte
+			var err error
+			if req.ContentLength < 2048 {
+				reqDump, err = httputil.DumpRequestOut(req, true)
+			} else {
+				reqDump = []byte("...large request omitted...")
+			}
 
-	h.logger.Debug(
-		"request",
-		zap.String("method", req.Method),
-		zap.Stringer("url", req.URL),
-	)
+			if err == nil {
+				h.logger.Debug(
+					"request",
+					zap.String("http.method", req.Method),
+					zap.Stringer("http.url", req.URL),
+					zap.String("http.request.dump", string(reqDump)),
+				)
+				return
+			}
+		}
+
+		h.logger.Debug(
+			"request",
+			zap.String("method", req.Method),
+			zap.Stringer("url", req.URL),
+		)
+	}()
 }
 
 func (h *loggingRoundTripper) afterSuccess(res *http.Response) {
-	// if the verbosity is all the way up, dump outgoing response bodies to logs
-	if h.verbosity > 2 {
-		resDump, err := httputil.DumpResponse(res, true)
-		if err == nil {
-			h.logger.Debug(
-				"response",
-				zap.String("http.method", res.Request.Method),
-				zap.Stringer("http.url", res.Request.URL),
-				zap.Int("http.status", res.StatusCode),
-				zap.String("http.response.dump", string(resDump)),
-			)
-			return
-		}
-	}
+	go func() {
+		// if the verbosity is all the way up, dump outgoing response bodies to logs
+		if h.verbosity > 2 {
+			var resDump []byte
+			var err error
+			if res.ContentLength < 2048 {
+				resDump, err = httputil.DumpResponse(res, true)
+			} else {
+				resDump = []byte("...large response omitted...")
+			}
 
-	h.logger.Debug(
-		"response",
-		zap.String("http.method", res.Request.Method),
-		zap.Stringer("http.url", res.Request.URL),
-		zap.Int("http.status", res.StatusCode),
-	)
+			if err == nil {
+				h.logger.Debug(
+					"response",
+					zap.String("http.method", res.Request.Method),
+					zap.Stringer("http.url", res.Request.URL),
+					zap.Int("http.status", res.StatusCode),
+					zap.String("http.response.dump", string(resDump)),
+				)
+				return
+			}
+		}
+
+		h.logger.Debug(
+			"response",
+			zap.String("http.method", res.Request.Method),
+			zap.Stringer("http.url", res.Request.URL),
+			zap.Int("http.status", res.StatusCode),
+		)
+	}()
 }
 
 func (h *loggingRoundTripper) afterError(res *http.Response, err error) {
-	method := "unknown"
-	url := "unknown"
-	status := 0
+	go func() {
+		method := "unknown"
+		url := "unknown"
+		status := 0
 
-	if res != nil && res.Request != nil {
-		method = res.Request.Method
-		url = res.Request.URL.String()
-		status = res.StatusCode
-	}
+		if res != nil && res.Request != nil {
+			method = res.Request.Method
+			url = res.Request.URL.String()
+			status = res.StatusCode
+		}
 
-	h.logger.Debug(
-		"response",
-		zap.String("http.method", method),
-		zap.String("http.url", url),
-		zap.Int("http.status", status),
-		zap.Error(err),
-	)
+		h.logger.Debug(
+			"response",
+			zap.String("http.method", method),
+			zap.String("http.url", url),
+			zap.Int("http.status", status),
+			zap.Error(err),
+		)
+	}()
 }

--- a/internal/output/stream.go
+++ b/internal/output/stream.go
@@ -25,6 +25,6 @@ func StreamOutput(reader io.ReadCloser, writer io.Writer) error {
 			break
 		}
 	}
-	
+
 	return nil
 }

--- a/internal/output/stream.go
+++ b/internal/output/stream.go
@@ -1,29 +1,24 @@
 package output
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 )
 
 func StreamOutput(reader io.ReadCloser, writer io.Writer) error {
-	buffer := make([]byte, 1024)
+	scanner := bufio.NewScanner(reader)
 
-	for {
-		n, err := reader.Read(buffer)
-		if err != nil && err != io.EOF {
+	for scanner.Scan() {
+		line := scanner.Text()
+		_, err := fmt.Fprintln(writer, line)
+		if err != nil {
 			return err
 		}
+	}
 
-		if n > 0 {
-			_, err = fmt.Fprintf(writer, "%s\n", string(buffer[:n]))
-			if err != nil {
-				return err
-			}
-		}
-
-		if err == io.EOF {
-			break
-		}
+	if err := scanner.Err(); err != nil {
+		return err
 	}
 
 	return nil

--- a/internal/output/text_test.go
+++ b/internal/output/text_test.go
@@ -6,10 +6,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/hathora/ci/internal/commands"
 	"github.com/hathora/ci/internal/sdk"
 	"github.com/hathora/ci/internal/sdk/models/shared"
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_DeploymentTextOutput(t *testing.T) {

--- a/internal/output/value.go
+++ b/internal/output/value.go
@@ -2,9 +2,10 @@ package output
 
 import (
 	"fmt"
-	"github.com/hathora/ci/internal/sdk/models/shared"
 	"io"
 	"strings"
+
+	"github.com/hathora/ci/internal/sdk/models/shared"
 )
 
 func ValueFormat(field string) FormatWriter {

--- a/internal/setup/http.go
+++ b/internal/setup/http.go
@@ -2,6 +2,7 @@ package setup
 
 import (
 	"github.com/hashicorp/go-cleanhttp"
+
 	"github.com/hathora/ci/internal/httputil"
 	"github.com/hathora/ci/internal/sdk"
 )

--- a/internal/shorthand/container_port.go
+++ b/internal/shorthand/container_port.go
@@ -1,13 +1,13 @@
 package shorthand
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
 
 	"github.com/hathora/ci/internal/sdk/models/shared"
-	"go.uber.org/multierr"
 )
 
 var (
@@ -43,9 +43,9 @@ func ParseContainerPort(s string) (*shared.ContainerPort, error) {
 			candidate := matches[i]
 			foundPort, portErr := strconv.Atoi(candidate)
 			port = foundPort
-			err = multierr.Append(err, portErr)
+			err = errors.Join(err, portErr)
 			if port < minPort || port > maxPort {
-				err = multierr.Append(err, fmt.Errorf("port outside of valid range (%d,%d): %d", minPort, maxPort, port))
+				err = errors.Join(err, fmt.Errorf("port outside of valid range (%d,%d): %d", minPort, maxPort, port))
 			}
 		case "transport":
 			candidate := matches[i]
@@ -57,12 +57,12 @@ func ParseContainerPort(s string) (*shared.ContainerPort, error) {
 			case "tls":
 				transportType = shared.TransportTypeTLS
 			default:
-				err = multierr.Append(err, fmt.Errorf("invalid transport type: %s", candidate))
+				err = errors.Join(err, fmt.Errorf("invalid transport type: %s", candidate))
 			}
 		case "name":
 			name = matches[i]
 			if !nameAllowedChars.MatchString(name) {
-				err = multierr.Append(err, fmt.Errorf("invalid name: %s", name))
+				err = errors.Join(err, fmt.Errorf("invalid name: %s", name))
 			}
 		}
 	}

--- a/internal/shorthand/container_port_test.go
+++ b/internal/shorthand/container_port_test.go
@@ -3,10 +3,11 @@ package shorthand_test
 import (
 	"testing"
 
-	"github.com/hathora/ci/internal/sdk/models/shared"
-	"github.com/hathora/ci/internal/shorthand"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hathora/ci/internal/sdk/models/shared"
+	"github.com/hathora/ci/internal/shorthand"
 )
 
 func Test_ContainerPortShorthand(t *testing.T) {

--- a/internal/shorthand/env_var_test.go
+++ b/internal/shorthand/env_var_test.go
@@ -3,10 +3,11 @@ package shorthand_test
 import (
 	"testing"
 
-	"github.com/hathora/ci/internal/sdk/models/shared"
-	"github.com/hathora/ci/internal/shorthand"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hathora/ci/internal/sdk/models/shared"
+	"github.com/hathora/ci/internal/shorthand"
 )
 
 func Test_DeploymentEnvVarShorthand(t *testing.T) {


### PR DESCRIPTION
From UX feedback:
- [x] Format build + deployment command be piped?
- [x] Test that all these file types work: `*.tar.tgz`, `*.tgz`, `*.tar.gz`
- [x] Test that build create tars up current working directory when . is passed in
- [x] Change ci to hathora
- [x] Add `hathora deploy` command which composes `hathora build create` and `hathora deployment create` 

From test feedback:
- [x] Incorporated changes to the windows install script from Justin Chu, updated to use the same app name (`s/hathora-ci/hathora`)

Additional changes:
- [x] Avoid panics in http middlewares
- [x] Reorder imports 
- [x] Change default output from prettified json to text (`--output json` will still be pretty by default)
- [x] Stream build run output line by line instead of 1024 characters at a time 
- [x] Fixed bug with shorthand verbose flag `-vvv`, which was off-by-one on the verbosity based on the number of flags (i.e. `-v` should be verbosity 1 but was 2 `-vv` should be 2 but was 3, etc) 
- [x] Cleaned up fatal error log to omit timestamp

To be delivered separately:
- Documentation updates to show the new `hathora deploy` command.