### PR TITLE
Log Command

### DIFF
--- a/internal/commands/altsrc/flaginit_test.go
+++ b/internal/commands/altsrc/flaginit_test.go
@@ -216,7 +216,7 @@ func Test_InitializeFlagSources(t *testing.T) {
 
 			err := cmd.Run(context.Background(), append([]string{"test"}, tt.args...))
 			if err != nil {
-				return 
+				return
 			}
 
 			assert.Equal(t, fmt.Sprintf("%v", tt.expectValue), flagValue)

--- a/internal/commands/app.go
+++ b/internal/commands/app.go
@@ -52,6 +52,7 @@ func App() *cli.Command {
 			Build,
 			Deploy,
 			Deployment,
+			Log,
 		},
 		After: func(ctx context.Context, c *cli.Command) error {
 			for _, fn := range cleanup {

--- a/internal/commands/log.go
+++ b/internal/commands/log.go
@@ -87,7 +87,7 @@ var (
 			altsrc.ConfigFile(configFlag.Name, "log.process-id"),
 		),
 		Category: "Log:",
-		Usage:    "System generated unique identifier to a runtime instance of your game server",
+		Usage:    "system generated unique identifier to a runtime instance of your game server",
 	}
 
 	tailLinesFlag = &workaround.IntFlag{
@@ -96,7 +96,7 @@ var (
 			cli.EnvVar(buildFlagEnvVar("TAIL_LINES")),
 			altsrc.ConfigFile(configFlag.Name, "log.tail-lines"),
 		),
-		Usage:      "Number of lines to return from most recent logs history.",
+		Usage:      "number of lines to return from most recent logs history.",
 		Value:      100,
 		Category:   "Log:",
 		Persistent: true,

--- a/internal/commands/log.go
+++ b/internal/commands/log.go
@@ -4,14 +4,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+
+	"github.com/urfave/cli/v3"
+	"go.uber.org/zap"
+
 	"github.com/hathora/ci/internal/commands/altsrc"
 	"github.com/hathora/ci/internal/output"
 	"github.com/hathora/ci/internal/sdk"
 	"github.com/hathora/ci/internal/setup"
 	"github.com/hathora/ci/internal/workaround"
-	"github.com/urfave/cli/v3"
-	"go.uber.org/zap"
-	"os"
 )
 
 var (
@@ -24,7 +26,7 @@ var Log = &cli.Command{
 	Usage: "view live process logs",
 	Flags: subcommandFlags(followFlag, processIDFlag, tailLinesFlag),
 	Action: func(ctx context.Context, cmd *cli.Command) error {
-		log, err := OneLogConfigFrom(cmd)
+		log, err := ProcessLogConfigFrom(cmd)
 		if err != nil {
 			//nolint:errcheck
 			cli.ShowSubcommandHelp(cmd)
@@ -129,19 +131,19 @@ func LogConfigFrom(cmd *cli.Command) (*LogConfig, error) {
 }
 
 var (
-	oneLogConfigKey = "commands.OneLogConfig.DI"
+	processLogConfigKey = "commands.ProcessLogConfig.DI"
 )
 
-type OneLogConfig struct {
+type ProcessLogConfig struct {
 	*LogConfig
 	Follow    bool
 	TailLines int
 	ProcessID string
 }
 
-var _ LoadableConfig = (*OneLogConfig)(nil)
+var _ LoadableConfig = (*ProcessLogConfig)(nil)
 
-func (c *OneLogConfig) Load(cmd *cli.Command) error {
+func (c *ProcessLogConfig) Load(cmd *cli.Command) error {
 	log, err := LogConfigFrom(cmd)
 	if err != nil {
 		return err
@@ -153,13 +155,13 @@ func (c *OneLogConfig) Load(cmd *cli.Command) error {
 	return nil
 }
 
-func (c *OneLogConfig) New() LoadableConfig { return &OneLogConfig{} }
+func (c *ProcessLogConfig) New() LoadableConfig { return &ProcessLogConfig{} }
 
-func OneLogConfigFrom(cmd *cli.Command) (*OneLogConfig, error) {
-	return ConfigFromCLI[*OneLogConfig](oneDeploymentConfigKey, cmd)
+func ProcessLogConfigFrom(cmd *cli.Command) (*ProcessLogConfig, error) {
+	return ConfigFromCLI[*ProcessLogConfig](processLogConfigKey, cmd)
 }
 
-func (c *OneLogConfig) Validate() error {
+func (c *ProcessLogConfig) Validate() error {
 	var err error
 	err = errors.Join(err, requireIntInRange(c.TailLines, minTailLines, maxTailLines, tailLinesFlag.Name))
 

--- a/internal/commands/log.go
+++ b/internal/commands/log.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 
@@ -52,7 +51,7 @@ var Log = &cli.Command{
 			return fmt.Errorf("failed to get logs: %w", err)
 		}
 
-		err = output.StreamOutput(res.Stream, os.Stderr)
+		err = output.StreamOutput(res.Stream, os.Stdout)
 		if err != nil {
 			zap.L().Error("failed to stream output to console", zap.Error(err))
 		}
@@ -73,7 +72,7 @@ var (
 		Sources: cli.NewValueSourceChain(
 			cli.EnvVar(logFlagEnvVar("FOLLOW")),
 			altsrc.ConfigFile(configFlag.Name, "log.follow")),
-		Usage:      "to streams logs in real time",
+		Usage:      "whether to stream logs in real time",
 		Value:      false,
 		Category:   "Log:",
 		Persistent: true,
@@ -87,7 +86,7 @@ var (
 			altsrc.ConfigFile(configFlag.Name, "log.process-id"),
 		),
 		Category: "Log:",
-		Usage:    "system generated unique identifier to a runtime instance of your game server",
+		Usage:    "`<id>` of the runtime instance of your game server",
 	}
 
 	tailLinesFlag = &workaround.IntFlag{
@@ -96,7 +95,7 @@ var (
 			cli.EnvVar(buildFlagEnvVar("TAIL_LINES")),
 			altsrc.ConfigFile(configFlag.Name, "log.tail-lines"),
 		),
-		Usage:      "number of lines to return from most recent logs history.",
+		Usage:      "`<number>` of lines to return from the most recent log history",
 		Value:      100,
 		Category:   "Log:",
 		Persistent: true,
@@ -162,8 +161,5 @@ func ProcessLogConfigFrom(cmd *cli.Command) (*ProcessLogConfig, error) {
 }
 
 func (c *ProcessLogConfig) Validate() error {
-	var err error
-	err = errors.Join(err, requireIntInRange(c.TailLines, minTailLines, maxTailLines, tailLinesFlag.Name))
-
-	return err
+	return requireIntInRange(c.TailLines, minTailLines, maxTailLines, tailLinesFlag.Name)
 }

--- a/internal/commands/log.go
+++ b/internal/commands/log.go
@@ -1,0 +1,169 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/hathora/ci/internal/commands/altsrc"
+	"github.com/hathora/ci/internal/output"
+	"github.com/hathora/ci/internal/sdk"
+	"github.com/hathora/ci/internal/setup"
+	"github.com/hathora/ci/internal/workaround"
+	"github.com/urfave/cli/v3"
+	"go.uber.org/zap"
+	"os"
+)
+
+var (
+	minTailLines = 0
+	maxTailLines = 5000
+)
+
+var Log = &cli.Command{
+	Name:  "log",
+	Usage: "view live process logs",
+	Flags: subcommandFlags(followFlag, processIDFlag, tailLinesFlag),
+	Action: func(ctx context.Context, cmd *cli.Command) error {
+		log, err := OneLogConfigFrom(cmd)
+		if err != nil {
+			//nolint:errcheck
+			cli.ShowSubcommandHelp(cmd)
+			return err
+		}
+
+		if err := log.Validate(); err != nil {
+			//nolint:errcheck
+			cli.ShowSubcommandHelp(cmd)
+			return err
+		}
+
+		log.Log.Debug("Getting build server logs...")
+
+		// validate
+
+		res, err := log.SDK.LogV1.GetLogsForProcess(
+			ctx,
+			log.ProcessID,
+			log.AppID,
+			sdk.Bool(log.Follow),
+			sdk.Int(log.TailLines))
+
+		if err != nil {
+			return fmt.Errorf("failed to get logs: %w", err)
+		}
+
+		err = output.StreamOutput(res.Stream, os.Stderr)
+		if err != nil {
+			zap.L().Error("failed to stream output to console", zap.Error(err))
+		}
+
+		return nil
+	},
+}
+
+func logFlagEnvVar(name string) string {
+	return logFlagEnvVarPrefix + name
+}
+
+var (
+	logFlagEnvVarPrefix = globalFlagEnvVarPrefix + "LOG_"
+
+	followFlag = &cli.BoolFlag{
+		Name: "follow",
+		Sources: cli.NewValueSourceChain(
+			cli.EnvVar(logFlagEnvVar("FOLLOW")),
+			altsrc.ConfigFile(configFlag.Name, "log.follow")),
+		Usage:      "to streams logs in real time",
+		Value:      false,
+		Category:   "Log:",
+		Persistent: true,
+	}
+
+	processIDFlag = &cli.StringFlag{
+		Name:    "process-id",
+		Aliases: []string{"p"},
+		Sources: cli.NewValueSourceChain(
+			cli.EnvVar(logFlagEnvVar("PROCESS_ID")),
+			altsrc.ConfigFile(configFlag.Name, "log.process-id"),
+		),
+		Category: "Log:",
+		Usage:    "System generated unique identifier to a runtime instance of your game server",
+	}
+
+	tailLinesFlag = &workaround.IntFlag{
+		Name: "tail-lines",
+		Sources: cli.NewValueSourceChain(
+			cli.EnvVar(buildFlagEnvVar("TAIL_LINES")),
+			altsrc.ConfigFile(configFlag.Name, "log.tail-lines"),
+		),
+		Usage:      "Number of lines to return from most recent logs history.",
+		Value:      100,
+		Category:   "Log:",
+		Persistent: true,
+	}
+)
+
+var (
+	logConfigKey = "commands.LogConfig.DI"
+)
+
+type LogConfig struct {
+	*GlobalConfig
+	SDK *sdk.SDK
+}
+
+var _ LoadableConfig = (*LogConfig)(nil)
+
+func (c *LogConfig) Load(cmd *cli.Command) error {
+	global, err := GlobalConfigFrom(cmd)
+	if err != nil {
+		return err
+	}
+	c.GlobalConfig = global
+	c.SDK = setup.SDK(c.Token, c.BaseURL, c.Verbosity)
+	return nil
+}
+
+func (c *LogConfig) New() LoadableConfig { return &LogConfig{} }
+
+func LogConfigFrom(cmd *cli.Command) (*LogConfig, error) {
+	return ConfigFromCLI[*LogConfig](logConfigKey, cmd)
+}
+
+var (
+	oneLogConfigKey = "commands.OneLogConfig.DI"
+)
+
+type OneLogConfig struct {
+	*LogConfig
+	Follow    bool
+	TailLines int
+	ProcessID string
+}
+
+var _ LoadableConfig = (*OneLogConfig)(nil)
+
+func (c *OneLogConfig) Load(cmd *cli.Command) error {
+	log, err := LogConfigFrom(cmd)
+	if err != nil {
+		return err
+	}
+	c.ProcessID = cmd.String(processIDFlag.Name)
+	c.Follow = cmd.Bool(followFlag.Name)
+	c.TailLines = int(cmd.Int(tailLinesFlag.Name))
+	c.LogConfig = log
+	return nil
+}
+
+func (c *OneLogConfig) New() LoadableConfig { return &OneLogConfig{} }
+
+func OneLogConfigFrom(cmd *cli.Command) (*OneLogConfig, error) {
+	return ConfigFromCLI[*OneLogConfig](oneDeploymentConfigKey, cmd)
+}
+
+func (c *OneLogConfig) Validate() error {
+	var err error
+	err = errors.Join(err, requireIntInRange(c.TailLines, minTailLines, maxTailLines, tailLinesFlag.Name))
+
+	return err
+}

--- a/internal/commands/log.go
+++ b/internal/commands/log.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	minTailLines = 0
+	minTailLines = 1
 	maxTailLines = 5000
 )
 
@@ -38,8 +38,6 @@ var Log = &cli.Command{
 		}
 
 		log.Log.Debug("Getting build server logs...")
-
-		// validate
 
 		res, err := log.SDK.LogV1.GetLogsForProcess(
 			ctx,


### PR DESCRIPTION
# Changes
- added a new log command that follows the pattern in the API docs.

## Tested By
- Ran the command with an active process and watched it tail the process.
- Ran the command with a dead process and watched it read the last N lines

## Logs
```
go run ./cmd/run.go log
NAME:
   hathora log - view live process logs

USAGE:
   hathora log [command [command options]] [arguments...]

COMMANDS:
   help, h  Shows a list of commands or help for one command

OPTIONS:
   --help, -h  show help (default: false)

   Global:

   --app-id <id>, -a <id>                     the <id> of the app in Hathora [$HATHORA_APP_ID]
   --config <path>, -c <path>                 <path> to the configuration file
   --hathora-cloud-endpoint <url>             override the default API base <url> (default: https://api.hathora.dev) [$HATHORA_CLOUD_ENDPOINT]
   --output <format>, -o <format>             the <format> of the output. Supported values: (json, text, value=buildId) (default: "text") [$HATHORA_OUTPUT]
   --pretty                                   enable pretty output (json only) (default: true)
   --token <access-token>, -t <access-token>  <access-token> for authenticating with the API [$HATHORA_TOKEN]
   --verbose, -v                              enable verbose logging (default: false)
   --verbosity <level>                        set the logging verbosity <level> (0-3) (default: 0) [$HATHORA_VERBOSITY]

   Log:

   --follow                      to streams logs in real time (default: false) [$HATHORA_LOG_FOLLOW]
   --process-id value, -p value  system generated unique identifier to a runtime instance of your game server [$HATHORA_LOG_PROCESS_ID]
   --tail-lines value            number of lines to return from most recent logs history. [$HATHORA_BUILD_TAIL_LINES]
```