### PR TITLE
Prelaunch bug-fixes

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -28,6 +28,6 @@ Invoke-WebRequest -Uri $downloadUrl -OutFile "$binaryName.exe"
 
 # Install the binary
 Write-Host "Installing $binaryName to $installDir..."
-Move-Item -Path "$binaryName.exe" -Destination $installDir
+Move-Item -Path "$binaryName.exe" -Destination $installDir -Force
 
 Write-Host "Installation complete!"

--- a/internal/archive/targz_test.go
+++ b/internal/archive/targz_test.go
@@ -1,0 +1,139 @@
+package archive_test
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/hathora/ci/internal/archive"
+)
+
+func Test_CreateTGZ(t *testing.T) {
+	zapLogger, _ := zap.NewDevelopment()
+	zap.ReplaceGlobals(zapLogger)
+	tests := []struct {
+		name       string
+		files      map[string]string
+		shouldFail bool
+	}{
+		{
+			name: "simple",
+			files: map[string]string{
+				"file1.txt":        "This is file 1",
+				"subdir/file2.txt": "This is file 2 in subdir",
+			},
+			shouldFail: false,
+		},
+		{
+			name: "nested",
+			files: map[string]string{
+				"dir1/dir2/file3.txt": "This is file 3 in nested directory",
+				"dir1/file4.txt":      "This is file 4",
+			},
+			shouldFail: false,
+		},
+		{
+			name: "nested with dirs only",
+			files: map[string]string{
+				"dir3/":               "",
+				"dir3/dir4/":          "",
+				"dir3/dir4/file5.txt": "This is file 5 in nested empty directory",
+			},
+			shouldFail: false,
+		},
+		{
+			name: "special characters in filenames",
+			files: map[string]string{
+				"file with spaces.txt":  "This is a file with spaces",
+				"file-with-üñîçødé.txt": "This file has unicode characters",
+			},
+			shouldFail: false,
+		},
+		{
+			name:       "empty",
+			files:      map[string]string{},
+			shouldFail: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			srcFolder, err := os.MkdirTemp("", "testsrc")
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				os.RemoveAll(srcFolder)
+			})
+
+			for path, content := range tt.files {
+				fullPath := filepath.Join(srcFolder, path)
+				if strings.HasSuffix(path, "/") {
+					require.NoError(t, os.MkdirAll(fullPath, os.ModePerm))
+				} else {
+					err := os.MkdirAll(filepath.Dir(fullPath), os.ModePerm)
+					require.NoError(t, err)
+					err = os.WriteFile(fullPath, []byte(content), 0644)
+					require.NoError(t, err)
+				}
+			}
+
+			archivePath, err := archive.CreateTGZ(srcFolder)
+			if tt.shouldFail {
+				assert.Error(err)
+				return
+			} else {
+				assert.NoError(err)
+			}
+			t.Cleanup(func() {
+				os.Remove(archivePath)
+			})
+
+			file, err := os.Open(archivePath)
+			assert.NoError(err)
+			t.Cleanup(func() {
+				file.Close()
+			})
+
+			gzipReader, err := gzip.NewReader(file)
+			assert.NoError(err)
+			t.Cleanup(func() {
+				gzipReader.Close()
+			})
+
+			tarReader := tar.NewReader(gzipReader)
+
+			archivedFiles := make(map[string]string)
+			for {
+				header, err := tarReader.Next()
+				if err == io.EOF {
+					break
+				}
+				assert.NoError(err)
+
+				if header.Typeflag == tar.TypeReg {
+					content, err := io.ReadAll(tarReader)
+					assert.NoError(err)
+					archivedFiles[header.Name] = string(content)
+				}
+			}
+
+			for path, expectedContent := range tt.files {
+				if strings.HasSuffix(path, "/") {
+					continue // Skip directories
+				}
+				content, found := archivedFiles[path]
+				assert.True(found, "Expected file %s not found in archive", path)
+				assert.Equal(expectedContent, content, "File content mismatch for %s", path)
+			}
+		})
+	}
+}

--- a/internal/commands/app.go
+++ b/internal/commands/app.go
@@ -14,22 +14,33 @@ var (
 	BuildVersion = "unknown"
 )
 
-func App() *cli.Command {
+func init() {
 	cli.VersionFlag = &cli.BoolFlag{
-		Name:  "version",
-		Usage: "print the version",
+		Name:     "version",
+		Usage:    "print the version",
+		Category: "Global:",
 	}
 
+	cli.HelpFlag = &cli.BoolFlag{
+		Name:     "help",
+		Aliases:  []string{"h"},
+		Usage:    "show help",
+		Category: "Global:",
+	}
+}
+
+func App() *cli.Command {
 	var cleanup []func()
 	return &cli.Command{
-		Name:                   "hathora",
-		EnableShellCompletion:  true,
-		Suggest:                true,
-		UseShortOptionHandling: true,
-		SliceFlagSeparator:     ",",
-		Usage:                  "a CLI tool for for CI/CD workflows to manage deployments and builds in hathora.dev",
-		Flags:                  GlobalFlags,
-		Version:                BuildVersion,
+		Name:                          "hathora",
+		EnableShellCompletion:         true,
+		Suggest:                       true,
+		UseShortOptionHandling:        true,
+		SliceFlagSeparator:            ",",
+		Usage:                         "a CLI tool for for CI/CD workflows to manage deployments and builds in hathora.dev",
+		Flags:                         GlobalFlags,
+		Version:                       BuildVersion,
+		CustomRootCommandHelpTemplate: cli.SubcommandHelpTemplate,
 		Before: func(ctx context.Context, cmd *cli.Command) error {
 			handleNewVersionAvailable(BuildVersion)
 
@@ -40,7 +51,7 @@ func App() *cli.Command {
 			if err != nil {
 				return err
 			}
-			cfg, err := GlobalConfigFrom(cmd)
+			cfg, err := VerbosityConfigFrom(cmd)
 			if err != nil {
 				return err
 			}

--- a/internal/commands/deployment.go
+++ b/internal/commands/deployment.go
@@ -10,6 +10,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/hathora/ci/internal/commands/altsrc"
+	"github.com/hathora/ci/internal/output"
 	"github.com/hathora/ci/internal/sdk"
 	"github.com/hathora/ci/internal/sdk/models/shared"
 	"github.com/hathora/ci/internal/setup"
@@ -313,7 +314,8 @@ var (
 
 type DeploymentConfig struct {
 	*GlobalConfig
-	SDK *sdk.SDK
+	SDK    *sdk.SDK
+	Output output.FormatWriter
 }
 
 var _ LoadableConfig = (*DeploymentConfig)(nil)
@@ -324,7 +326,14 @@ func (c *DeploymentConfig) Load(cmd *cli.Command) error {
 		return err
 	}
 	c.GlobalConfig = global
+
 	c.SDK = setup.SDK(c.Token, c.BaseURL, c.Verbosity)
+	var deployment shared.DeploymentV2
+	output, err := OutputFormatterFor(cmd, deployment)
+	if err != nil {
+		return err
+	}
+	c.Output = output
 	return nil
 }
 

--- a/internal/commands/flags.go
+++ b/internal/commands/flags.go
@@ -7,17 +7,18 @@ import (
 )
 
 var (
-	outputTypeFlag = &cli.StringFlag{
+	outputFlag = &cli.StringFlag{
 		Name:    "output",
 		Aliases: []string{"o"},
 		Sources: cli.NewValueSourceChain(
 			cli.EnvVar(globalFlagEnvVar("OUTPUT")),
 			altsrc.ConfigFile(configFlag.Name, "global.output"),
 		),
-		Usage:      "the `<format>` of the output. Supported values: (json, text, value=buildId)",
-		Value:      "text",
-		Persistent: true,
-		Category:   "Global:",
+		Usage:       "the `<format>` of the output. Supported values: (json, text, buildIdValue)",
+		Value:       "text",
+		DefaultText: "text",
+		Persistent:  true,
+		Category:    "Global:",
 	}
 
 	outputPrettyFlag = &cli.BoolFlag{
@@ -38,7 +39,6 @@ var (
 		Usage:      "the `<id>` of the app in Hathora",
 		Category:   "Global:",
 		Persistent: true,
-		Required:   true,
 	}
 
 	verboseFlag = &cli.BoolFlag{
@@ -68,6 +68,7 @@ var (
 			altsrc.ConfigFile(configFlag.Name, "global.cloud-endpoint"),
 		),
 		Usage:       "override the default API base `<url>`",
+		Value:       "https://api.hathora.dev",
 		DefaultText: "https://api.hathora.dev",
 		Category:    "Global:",
 		Persistent:  true,
@@ -80,7 +81,6 @@ var (
 		Usage:      "`<access-token>` for authenticating with the API",
 		Category:   "Global:",
 		Persistent: true,
-		Required:   true,
 	}
 
 	configFlag = &cli.StringFlag{
@@ -95,7 +95,7 @@ var (
 		appIDFlag,
 		hathoraCloudEndpointFlag,
 		tokenFlag,
-		outputTypeFlag,
+		outputFlag,
 		outputPrettyFlag,
 		verboseFlag,
 		verbosityFlag,

--- a/internal/output/types.go
+++ b/internal/output/types.go
@@ -24,7 +24,7 @@ func (o Type) String() string {
 
 func ParseOutputType(s string) Type {
 	lowercaseOutputType := strings.ToLower(s)
-	if strings.HasPrefix(lowercaseOutputType, "value=") {
+	if strings.HasSuffix(lowercaseOutputType, "value") {
 		return Value
 	}
 	switch lowercaseOutputType {


### PR DESCRIPTION
Includes changes:
- Fix for windows upgrade path in install.ps1
- Command-specific output formatters to validate output types against the command being run
- Rename from `--output value=buildId` -> `--output buildIdValue`
- Test for tgz creation to repro tar contents issue on Windows, and relevant fix
- Only require appID and token if the command isn't `help`, don't require them to be on the top level command