### PR TITLE
Fix version check to show if there's a newer release than the installed binary

### DIFF
--- a/internal/commands/app.go
+++ b/internal/commands/app.go
@@ -42,21 +42,22 @@ func App() *cli.Command {
 		Version:                       BuildVersion,
 		CustomRootCommandHelpTemplate: cli.SubcommandHelpTemplate,
 		Before: func(ctx context.Context, cmd *cli.Command) error {
-			handleNewVersionAvailable(BuildVersion)
-
-			if isCallForHelp(cmd) {
-				return nil
-			}
-			err := altsrc.InitializeValueSourcesFromFlags(ctx, cmd, os.Args[1:])
-			if err != nil {
-				return err
-			}
 			cfg, err := VerbosityConfigFrom(cmd)
 			if err != nil {
 				return err
 			}
 			_, cleanupLogger := setup.Logger(cfg.Verbosity)
 			cleanup = append(cleanup, cleanupLogger)
+			handleNewVersionAvailable(BuildVersion)
+
+			if isCallForHelp(cmd) {
+				return nil
+			}
+
+			err = altsrc.InitializeValueSourcesFromFlags(ctx, cmd, os.Args[1:])
+			if err != nil {
+				return err
+			}
 			return nil
 		},
 		Commands: []*cli.Command{

--- a/internal/commands/common.go
+++ b/internal/commands/common.go
@@ -252,9 +252,17 @@ func handleNewVersionAvailable(currentVersion string) {
 		zap.L().Warn("unable to decode the latest version number")
 	}
 
-	versionDiff := version.Compare(release.TagName, currentVersion)
+	prefixedVersion := "go" + currentVersion
+	showLatest := false
+	if !version.IsValid(prefixedVersion) {
+		zap.L().Warn("You are using a development version of the hathora cli.")
+		showLatest = true
+	} else if version.Compare("go"+release.TagName, prefixedVersion) > 0 {
+		zap.L().Warn("You are using an outdated version of the hathora cli.")
+		showLatest = true
+	}
 
-	if versionDiff > 0 {
-		zap.L().Warn("A new version of hathora-ci is available for download.")
+	if showLatest {
+		zap.L().Warn("Version " + release.TagName + " is available for download.")
 	}
 }


### PR DESCRIPTION
This change fixes the version check that runs at the start of the command and prints a warning if you're running a version other than the latest release version.