### PR TITLE
Updating tail lines text, and required flags

### DIFF
--- a/internal/commands/log.go
+++ b/internal/commands/log.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 
@@ -161,5 +162,12 @@ func ProcessLogConfigFrom(cmd *cli.Command) (*ProcessLogConfig, error) {
 }
 
 func (c *ProcessLogConfig) Validate() error {
-	return requireIntInRange(c.TailLines, minTailLines, maxTailLines, tailLinesFlag.Name)
+	var err error
+	err = errors.Join(err, requireIntInRange(c.TailLines, minTailLines, maxTailLines, tailLinesFlag.Name))
+
+	if c.ProcessID == "" {
+		err = errors.Join(err, missingRequiredFlag(processIDFlag.Name))
+	}
+
+	return err
 }

--- a/internal/commands/log.go
+++ b/internal/commands/log.go
@@ -95,7 +95,7 @@ var (
 			cli.EnvVar(buildFlagEnvVar("TAIL_LINES")),
 			altsrc.ConfigFile(configFlag.Name, "log.tail-lines"),
 		),
-		Usage:      "`<number>` of lines to return from the most recent log history",
+		Usage:      "`<number>` of lines to return from the most recent log history (1-5000)",
 		Value:      100,
 		Category:   "Log:",
 		Persistent: true,


### PR DESCRIPTION
# Changes
- Updating the tail lines command description to include the allowed range of values
- Updated process ID to be required


## Logs
```
~/repos/hathora/ci git:[tail-line-update]
go run ./cmd/run.go log -a app-<redacted> --follow --tail-lines 100 | grep LogNats
WARN    You are using a development version of the hathora cli.
WARN    Version 0.0.9 is available for download.
[ERROR] Required flag "process-id" is not set
exit status 1
```