### PR TITLE
Fixing idle timeout/from latest

### DIFF
--- a/internal/commands/deploy.go
+++ b/internal/commands/deploy.go
@@ -6,10 +6,11 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/hathora/ci/internal/sdk/models/shared"
-	"github.com/hathora/ci/internal/shorthand"
 	"github.com/urfave/cli/v3"
 	"go.uber.org/zap"
+
+	"github.com/hathora/ci/internal/sdk/models/shared"
+	"github.com/hathora/ci/internal/shorthand"
 )
 
 var Deploy = &cli.Command{

--- a/internal/commands/deployment.go
+++ b/internal/commands/deployment.go
@@ -410,7 +410,6 @@ func (c *CreateDeploymentConfig) Load(cmd *cli.Command) error {
 	c.ContainerPort = int(cmd.Int(containerPortFlag.Name))
 	c.RequestedMemoryMB = cmd.Float(requestedMemoryFlag.Name)
 	c.RequestedCPU = cmd.Float(requestedCPUFlag.Name)
-	c.IdleTimeoutEnabled = sdk.Bool(cmd.Bool(idleTimeoutFlag.Name))
 
 	addlPorts := cmd.StringSlice(additionalContainerPortsFlag.Name)
 	parsedAddlPorts, err := parseContainerPorts(addlPorts)


### PR DESCRIPTION
# Changes
- We were setting the idle timeout flag twice, once where we allowed allowed it to be nil, and a second time where we forced it to be a value. So later when we merged the config, it was always set, and never using from-latest.
- Removed the second setting of the value, and confirmed that it was not being set so it would use the value from the latest deploy