### PR TITLE
Updating idle timeout logic

### DIFF
--- a/internal/commands/deploy.go
+++ b/internal/commands/deploy.go
@@ -113,14 +113,9 @@ func (c *DeployConfig) Merge(latest *shared.DeploymentV2, isIdleTimeoutDefault b
 		return
 	}
 
-	zap.L().Warn("Second round",
-		zap.Bool("isDefault", isIdleTimeoutDefault),
-		zap.Bool("Latest", latest.IdleTimeoutEnabled))
 	if !isIdleTimeoutDefault {
 		c.IdleTimeoutEnabled = &latest.IdleTimeoutEnabled
 	}
-
-	zap.L().Warn("Final", zap.Bool("idle timeout", *c.IdleTimeoutEnabled))
 
 	if c.RoomsPerProcess == 0 {
 		c.RoomsPerProcess = latest.RoomsPerProcess

--- a/internal/commands/deploy.go
+++ b/internal/commands/deploy.go
@@ -45,7 +45,7 @@ var Deploy = &cli.Command{
 				return fmt.Errorf("unable to retrieve latest deployment: %w", err)
 			}
 
-			deploy.Merge(res.DeploymentV2)
+			deploy.Merge(res.DeploymentV2, cmd.IsSet(idleTimeoutFlag.Name))
 		}
 
 		if err := deploy.Validate(); err != nil {
@@ -108,14 +108,19 @@ func (c *DeployConfig) Load(cmd *cli.Command) error {
 	return nil
 }
 
-func (c *DeployConfig) Merge(latest *shared.DeploymentV2) {
+func (c *DeployConfig) Merge(latest *shared.DeploymentV2, isIdleTimeoutDefault bool) {
 	if latest == nil {
 		return
 	}
 
-	if c.IdleTimeoutEnabled == nil {
+	zap.L().Warn("Second round",
+		zap.Bool("isDefault", isIdleTimeoutDefault),
+		zap.Bool("Latest", latest.IdleTimeoutEnabled))
+	if !isIdleTimeoutDefault {
 		c.IdleTimeoutEnabled = &latest.IdleTimeoutEnabled
 	}
+
+	zap.L().Warn("Final", zap.Bool("idle timeout", *c.IdleTimeoutEnabled))
 
 	if c.RoomsPerProcess == 0 {
 		c.RoomsPerProcess = latest.RoomsPerProcess

--- a/internal/commands/deployment.go
+++ b/internal/commands/deployment.go
@@ -197,7 +197,6 @@ var (
 			cli.EnvVar(deploymentEnvVar("IDLE_TIMEOUT_ENABLED")),
 			altsrc.ConfigFile(configFlag.Name, "deployment.idle-timeout-enabled"),
 		),
-		Value:      false,
 		Usage:      "whether to shut down processes that have had no new connections or rooms for five minutes",
 		Persistent: true,
 		Category:   "Deployment:",
@@ -401,10 +400,23 @@ func (c *CreateDeploymentConfig) Load(cmd *cli.Command) error {
 
 	c.DeploymentConfig = deployment
 	c.BuildID = int(cmd.Int(buildIDFlag.Name))
+
+	// Value of the idleTimeoutFlag by priority, high to low
+	// Passed in as an argument
+	// From latest deployment config (if from-latest is true)
+	// Default true
+	zap.L().Warn("FLAG",
+		zap.Any("is set", cmd.IsSet(idleTimeoutFlag.Name)),
+		zap.Any("value", cmd.Bool(idleTimeoutFlag.Name)))
 	if cmd.IsSet(idleTimeoutFlag.Name) {
 		idleTimeoutEnabled := cmd.Bool(idleTimeoutFlag.Name)
 		c.IdleTimeoutEnabled = &idleTimeoutEnabled
+	} else {
+		idleTimeoutEnabled := true
+		c.IdleTimeoutEnabled = &idleTimeoutEnabled
 	}
+
+	zap.L().Warn("First round value", zap.Bool("idle timeout enabled", *c.IdleTimeoutEnabled))
 	c.RoomsPerProcess = int(cmd.Int(roomsPerProcessFlag.Name))
 	c.TransportType = shared.TransportType(cmd.String(transportTypeFlag.Name))
 	c.ContainerPort = int(cmd.Int(containerPortFlag.Name))

--- a/internal/commands/deployment.go
+++ b/internal/commands/deployment.go
@@ -405,9 +405,6 @@ func (c *CreateDeploymentConfig) Load(cmd *cli.Command) error {
 	// Passed in as an argument
 	// From latest deployment config (if from-latest is true)
 	// Default true
-	zap.L().Warn("FLAG",
-		zap.Any("is set", cmd.IsSet(idleTimeoutFlag.Name)),
-		zap.Any("value", cmd.Bool(idleTimeoutFlag.Name)))
 	if cmd.IsSet(idleTimeoutFlag.Name) {
 		idleTimeoutEnabled := cmd.Bool(idleTimeoutFlag.Name)
 		c.IdleTimeoutEnabled = &idleTimeoutEnabled
@@ -416,7 +413,6 @@ func (c *CreateDeploymentConfig) Load(cmd *cli.Command) error {
 		c.IdleTimeoutEnabled = &idleTimeoutEnabled
 	}
 
-	zap.L().Warn("First round value", zap.Bool("idle timeout enabled", *c.IdleTimeoutEnabled))
 	c.RoomsPerProcess = int(cmd.Int(roomsPerProcessFlag.Name))
 	c.TransportType = shared.TransportType(cmd.String(transportTypeFlag.Name))
 	c.ContainerPort = int(cmd.Int(containerPortFlag.Name))


### PR DESCRIPTION
# Changes
- a previous change that fixed a bug where the idle-timeout-enabled flag was not being respected in from latest, resulted in a new issue where we were de-referencing a possibly nil value
- This PR updates the idle-timeout-enabled flag to respect a passed in flag as the highest priority, then the value from latest (if applicable), and default to true if no value is passed in

## Tested By
- Ran the CLI with a passed in value and from latest, confirmed it used the passed in value
- Ran the CLI without a passed in version, and from latest, and used the latest
- Ran the CLI with no value, and it used true