### PR TITLE
improve powershell install script

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1,9 +1,10 @@
+# Enable strict mode and exit on error
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
 $repoOwner = "hathora"
 $repoName = "ci"
 $binaryName = "hathora"
-
-# Get the latest release tag from GitHub
-$latestRelease = (Invoke-WebRequest "https://api.github.com/repos/$repoOwner/$repoName/releases/latest" | ConvertFrom-Json).tag_name
 
 # Detect the architecture
 $arch = $env:PROCESSOR_ARCHITECTURE
@@ -17,17 +18,13 @@ if ($arch -eq "AMD64") {
 }
 
 # Set the download URL for the Windows binary based on the architecture
-$downloadUrl = "https://github.com/$repoOwner/$repoName/releases/download/$latestRelease/$binaryName-windows-$arch"
+$downloadUrl = "https://github.com/$repoOwner/$repoName/releases/latest/download/$binaryName-windows-$arch.exe"
 
 # Set the install directory
 $installDir = "$env:LOCALAPPDATA\Microsoft\WindowsApps"
 
-# Download the binary
-Write-Host "Downloading $binaryName for $arch..."
-Invoke-WebRequest -Uri $downloadUrl -OutFile "$binaryName.exe"
-
-# Install the binary
-Write-Host "Installing $binaryName to $installDir..."
-Move-Item -Path "$binaryName.exe" -Destination $installDir -Force
+# Download and install the binary directly to the destination
+Write-Host "Downloading and installing $binaryName for $arch to $installDir..."
+Invoke-WebRequest -Uri $downloadUrl -OutFile "$installDir\$binaryName.exe"
 
 Write-Host "Installation complete!"


### PR DESCRIPTION
Ran into a couple errors testing this for our mutual friends

* Enable strict mode and exit script on first error
* Release binaries have `.exe` now
* Don't get the latest release from the api, just download from the latest release directly (was hitting rate limits because of other API calls)
* Download the binary directly into the install directory so failures don't leave you with a copy of the file in current dir