### PR TITLE
fix powershell install binary download performance

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1,6 +1,7 @@
 # Enable strict mode and exit on error
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
 
 $repoOwner = "hathora"
 $repoName = "ci"


### PR DESCRIPTION
Powershell has a fun default behavior of updating a progress bar on _every byte_ when downloading a file using `Invoke-WebRequest`. This significantly slows down the download. Setting `$ProgressPreference = "SilentlyContinue"` disables the progress bar and speeds up the download.

In our CI this change reduces the execution time from 17s -> less than 1s

https://stackoverflow.com/questions/28682642/powershell-why-is-using-invoke-webrequest-much-slower-than-a-browser-download