### PR TITLE
allow overriding cli version in powershell installation script

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -18,14 +18,19 @@ if ($arch -eq "AMD64") {
     exit 1
 }
 
-# Set the download URL for the Windows binary based on the architecture
-$downloadUrl = "https://github.com/$repoOwner/$repoName/releases/latest/download/$binaryName-windows-$arch.exe"
-
 # Set the install directory
 $installDir = "$env:LOCALAPPDATA\Microsoft\WindowsApps"
 
+# Set the download URL for the Windows binary based on the architecture and version
+if ($env:HATHORA_CLI_VERSION) {
+    $downloadUrl = "https://github.com/$repoOwner/$repoName/releases/download/$env:HATHORA_CLI_VERSION/$binaryName-windows-$arch.exe"
+    Write-Host "Downloading and installing $binaryName version $env:HATHORA_CLI_VERSION for $arch to $installDir..."
+} else {
+    $downloadUrl = "https://github.com/$repoOwner/$repoName/releases/latest/download/$binaryName-windows-$arch.exe"
+    Write-Host "Downloading and installing latest version of $binaryName for $arch to $installDir..."
+}
+
 # Download and install the binary directly to the destination
-Write-Host "Downloading and installing $binaryName for $arch to $installDir..."
 Invoke-WebRequest -Uri $downloadUrl -OutFile "$installDir\$binaryName.exe"
 
 Write-Host "Installation complete!"


### PR DESCRIPTION
Updates the powershell install script to allow customizing the version of the CLI installed, still defaulting to latest.

You can now `$env:HATHORA_CLI_VERSION="0.2.0"; iwr -useb https://raw.githubusercontent.com/hathora/ci/main/install.ps1 | iex`

Note that I first tried to do this having the script take a param, however it seems it is not currently possible to specify arguments when piping a script to `iex`. See [here](https://github.com/PowerShell/PowerShell/issues/23836)