### PR TITLE
Added support for more complex environmental variable values passed with --env

### DIFF
--- a/internal/shorthand/env_var.go
+++ b/internal/shorthand/env_var.go
@@ -12,15 +12,33 @@ func ParseDeploymentEnvVar(s string) (*shared.DeploymentConfigV3Env, error) {
 		return nil, fmt.Errorf("env var cannot be empty")
 	}
 
-	parts := strings.Split(s, "=")
+	parts := strings.SplitN(s, "=", 2)
 	if len(parts) != 2 {
 		return nil, fmt.Errorf("invalid env var format: %s", s)
 	}
 
+	key := strings.TrimSpace(parts[0])
+	value := strings.TrimSpace(parts[1])
+	value = TrimSingleOuterQuote(value)
+
 	return &shared.DeploymentConfigV3Env{
-		Name:  strings.TrimSpace(parts[0]),
-		Value: strings.TrimSpace(parts[1]),
+		Name:  key,
+		Value: value,
 	}, nil
+}
+
+func TrimSingleOuterQuote(s string) string {
+	if len(s) > 0 {
+		lastChar := s[len(s)-1]
+		if lastChar == '"' {
+			s = strings.Trim(s, `"`)
+		}
+		if lastChar == '\'' {
+			s = strings.Trim(s, `'`)
+		}
+	}
+
+	return s
 }
 
 func MapEnvToEnvConfig(input []shared.DeploymentV3Env) []shared.DeploymentConfigV3Env {

--- a/internal/shorthand/env_var.go
+++ b/internal/shorthand/env_var.go
@@ -17,28 +17,10 @@ func ParseDeploymentEnvVar(s string) (*shared.DeploymentConfigV3Env, error) {
 		return nil, fmt.Errorf("invalid env var format: %s", s)
 	}
 
-	key := strings.TrimSpace(parts[0])
-	value := strings.TrimSpace(parts[1])
-	value = TrimSingleOuterQuote(value)
-
 	return &shared.DeploymentConfigV3Env{
-		Name:  key,
-		Value: value,
+		Name:  strings.TrimSpace(parts[0]),
+		Value: strings.TrimSpace(parts[1]),
 	}, nil
-}
-
-func TrimSingleOuterQuote(s string) string {
-	if len(s) > 0 {
-		lastChar := s[len(s)-1]
-		if lastChar == '"' {
-			s = strings.Trim(s, `"`)
-		}
-		if lastChar == '\'' {
-			s = strings.Trim(s, `'`)
-		}
-	}
-
-	return s
 }
 
 func MapEnvToEnvConfig(input []shared.DeploymentV3Env) []shared.DeploymentConfigV3Env {

--- a/internal/shorthand/env_var_test.go
+++ b/internal/shorthand/env_var_test.go
@@ -48,6 +48,22 @@ func Test_DeploymentEnvVarShorthand(t *testing.T) {
 			input:     "",
 			expectErr: true,
 		},
+		{
+			name:  "complex cli flag in single quotes",
+			input: `KEY='-SomeFlag="With Spaces,And Commas"'`,
+			expect: &shared.DeploymentConfigV3Env{
+				Name:  "KEY",
+				Value: `-SomeFlag="With Spaces,And Commas"`,
+			},
+		},
+		{
+			name:  "complex cli flag in double quotes",
+			input: `KEY="-SomeFlag='With Spaces,And Commas'"`,
+			expect: &shared.DeploymentConfigV3Env{
+				Name:  "KEY",
+				Value: `-SomeFlag='With Spaces,And Commas'`,
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/shorthand/env_var_test.go
+++ b/internal/shorthand/env_var_test.go
@@ -44,19 +44,11 @@ func Test_DeploymentEnvVarShorthand(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name:  "value with double quotes within single quotes",
-			input: `KEY='-SomeFlag="With Spaces,And Commas"'`,
+			name:  "nested flag",
+			input: `KEY=-SomeFlag="With Spaces,And Commas"`,
 			expect: &shared.DeploymentConfigV3Env{
 				Name:  "KEY",
 				Value: `-SomeFlag="With Spaces,And Commas"`,
-			},
-		},
-		{
-			name:  "value with singles quotes within double quotes",
-			input: `KEY="-SomeFlag='With Spaces,And Commas'"`,
-			expect: &shared.DeploymentConfigV3Env{
-				Name:  "KEY",
-				Value: `-SomeFlag='With Spaces,And Commas'`,
 			},
 		},
 	}

--- a/internal/shorthand/env_var_test.go
+++ b/internal/shorthand/env_var_test.go
@@ -34,11 +34,6 @@ func Test_DeploymentEnvVarShorthand(t *testing.T) {
 			},
 		},
 		{
-			name:      "name and value and extra",
-			input:     "NAME=VALUE=EXTRA",
-			expectErr: true,
-		},
-		{
 			name:      "key only",
 			input:     "KEY",
 			expectErr: true,
@@ -49,7 +44,7 @@ func Test_DeploymentEnvVarShorthand(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name:  "complex cli flag in single quotes",
+			name:  "value with double quotes within single quotes",
 			input: `KEY='-SomeFlag="With Spaces,And Commas"'`,
 			expect: &shared.DeploymentConfigV3Env{
 				Name:  "KEY",
@@ -57,7 +52,7 @@ func Test_DeploymentEnvVarShorthand(t *testing.T) {
 			},
 		},
 		{
-			name:  "complex cli flag in double quotes",
+			name:  "value with singles quotes within double quotes",
 			input: `KEY="-SomeFlag='With Spaces,And Commas'"`,
 			expect: &shared.DeploymentConfigV3Env{
 				Name:  "KEY",


### PR DESCRIPTION
This extends the `--env` command to accept more complex values.

New patterns that are supported:
- `--env FOO=-BAR=BAZ` is interpreted as key `FOO`, value `-BAR=BAZ`
- `--env FOO=BAR,BAZ` is interpreted as key `FOO`, value `BAR,BAZ`
- `--env 'FOO="BAR BAZ"'` is interpreted as key `FOO`, value `"BAR BAZ"`

All of this while still supporting multiple comma-delimited values passed to a single `--env`

- `--env FOO=BAR,BAZ,QUX=QUUX` is interpreted as two values:
    - key `FOO`, value `BAR,BAZ`
    - key `QUX`, value `QUUX`