### PR TITLE
Add workaround flags to altsrc

### DIFF
--- a/internal/commands/altsrc/flaginit.go
+++ b/internal/commands/altsrc/flaginit.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/hathora/ci/internal/workaround"
 	"github.com/urfave/cli/v3"
 )
 
@@ -177,6 +178,18 @@ func getSourcesFromFlag(flag cli.Flag) []cli.ValueSource {
 	}
 
 	if flag, ok := flag.(*cli.StringMapFlag); ok {
+		if flag.Sources.Chain != nil {
+			sources = append(sources, flag.Sources.Chain...)
+		}
+	}
+
+	if flag, ok := flag.(*workaround.IntFlag); ok {
+		if flag.Sources.Chain != nil {
+			sources = append(sources, flag.Sources.Chain...)
+		}
+	}
+
+	if flag, ok := flag.(*workaround.FloatFlag); ok {
 		if flag.Sources.Chain != nil {
 			sources = append(sources, flag.Sources.Chain...)
 		}


### PR DESCRIPTION
Supersedes #59 as the upgrade has become unwieldy.

This allows float and integer flags to be specified in the configuration file.