### PR TITLE
Exit code 1 if build fails

### DIFF
--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -100,6 +100,10 @@ var Build = &cli.Command{
 					return err
 				}
 
+				if created.Status == components.BuildStatusFailed {
+					return fmt.Errorf("Build failed")
+				}
+
 				return build.Output.Write(created, os.Stdout)
 			},
 		},


### PR DESCRIPTION
Currently we return exit code 0 if the build fails
