### PR TITLE
reduce min memory 1024 -> 512 (MB)

### DIFF
--- a/internal/commands/deployment.go
+++ b/internal/commands/deployment.go
@@ -31,7 +31,7 @@ var (
 	minCPU                = 0.25
 	maxCPUDecimalPlaces   = 2
 	maxCPU                = float64(4)
-	minMemoryMB           = float64(1024)
+	minMemoryMB           = float64(512)
 	maxMemoryMB           = float64(8192)
 )
 


### PR DESCRIPTION
This change reduces the minimum allowed memory on a deployment/deploy from 1024 to 512MB.